### PR TITLE
ci: セキュリティスキャンジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
 
       - name: Run gosec (backend)
         working-directory: backend
@@ -206,6 +206,6 @@ jobs:
         continue-on-error: true
         run: |
           echo "::group::govulncheck results"
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./... || echo "::warning::govulncheck found vulnerabilities"
           echo "::endgroup::"


### PR DESCRIPTION
## Summary
- CIにセキュリティスキャンジョブを新規追加
- フロントエンド: `npm audit --audit-level=high`で高リスクな脆弱性をチェック
- バックエンド: `gosec`で静的セキュリティ解析
- バックエンド: `govulncheck`でGoモジュールの脆弱性チェック

## Test plan
- [x] ワークフロー構文が正しいことを確認
- [ ] CIで新しいセキュリティスキャンジョブが実行される

Note: スキャンは情報提供目的であり、CIをブロックしません（continue-on-error: true）

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)