### PR TITLE
feat: steps/edges/block_groups/step_runsにテナント分離を追加

### DIFF
--- a/backend/cmd/worker/main.go
+++ b/backend/cmd/worker/main.go
@@ -262,7 +262,7 @@ func processJob(
 		)
 
 		// Get max attempt for the entire run (Run-level unique)
-		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, job.RunID)
+		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, run.TenantID, job.RunID)
 		if err != nil {
 			logger.Warn("Failed to get max attempt, defaulting to 0", "error", err)
 			maxAttempt = 0
@@ -303,7 +303,7 @@ func processJob(
 		)
 
 		// Get max attempt for the entire run (Run-level unique)
-		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, job.RunID)
+		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, run.TenantID, job.RunID)
 		if err != nil {
 			logger.Warn("Failed to get max attempt, defaulting to 0", "error", err)
 			maxAttempt = 0
@@ -338,7 +338,7 @@ func processJob(
 		}
 
 		// Get max attempt for the entire run (Run-level unique)
-		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, job.RunID)
+		maxAttempt, err := stepRunRepo.GetMaxAttemptForRun(ctx, run.TenantID, job.RunID)
 		if err != nil {
 			logger.Warn("Failed to get max attempt, defaulting to 0", "error", err)
 			maxAttempt = 0

--- a/backend/internal/domain/block_group.go
+++ b/backend/internal/domain/block_group.go
@@ -84,6 +84,7 @@ func (r GroupRole) IsValid() bool {
 // BlockGroup represents a control flow construct that groups multiple steps
 type BlockGroup struct {
 	ID            uuid.UUID       `json:"id"`
+	TenantID      uuid.UUID       `json:"tenant_id"`
 	WorkflowID    uuid.UUID       `json:"workflow_id"`
 	Name          string          `json:"name"`
 	Type          BlockGroupType  `json:"type"`
@@ -98,10 +99,11 @@ type BlockGroup struct {
 }
 
 // NewBlockGroup creates a new block group
-func NewBlockGroup(workflowID uuid.UUID, name string, groupType BlockGroupType) *BlockGroup {
+func NewBlockGroup(tenantID, workflowID uuid.UUID, name string, groupType BlockGroupType) *BlockGroup {
 	now := time.Now().UTC()
 	return &BlockGroup{
 		ID:         uuid.New(),
+		TenantID:   tenantID,
 		WorkflowID: workflowID,
 		Name:       name,
 		Type:       groupType,
@@ -175,6 +177,7 @@ type WhileConfig struct {
 // BlockGroupRun represents the execution state of a block group
 type BlockGroupRun struct {
 	ID           uuid.UUID       `json:"id"`
+	TenantID     uuid.UUID       `json:"tenant_id"`
 	RunID        uuid.UUID       `json:"run_id"`
 	BlockGroupID uuid.UUID       `json:"block_group_id"`
 	Status       StepRunStatus   `json:"status"`
@@ -188,10 +191,11 @@ type BlockGroupRun struct {
 }
 
 // NewBlockGroupRun creates a new block group run
-func NewBlockGroupRun(runID, blockGroupID uuid.UUID) *BlockGroupRun {
+func NewBlockGroupRun(tenantID, runID, blockGroupID uuid.UUID) *BlockGroupRun {
 	now := time.Now().UTC()
 	return &BlockGroupRun{
 		ID:           uuid.New(),
+		TenantID:     tenantID,
 		RunID:        runID,
 		BlockGroupID: blockGroupID,
 		Status:       StepRunStatusPending,

--- a/backend/internal/domain/edge.go
+++ b/backend/internal/domain/edge.go
@@ -9,6 +9,7 @@ import (
 // Edge represents a connection between two steps in the DAG
 type Edge struct {
 	ID           uuid.UUID `json:"id"`
+	TenantID     uuid.UUID `json:"tenant_id"`
 	WorkflowID   uuid.UUID `json:"workflow_id"`
 	SourceStepID uuid.UUID `json:"source_step_id"`
 	TargetStepID uuid.UUID `json:"target_step_id"`
@@ -19,13 +20,14 @@ type Edge struct {
 }
 
 // NewEdge creates a new edge
-func NewEdge(workflowID, sourceStepID, targetStepID uuid.UUID, condition string) *Edge {
+func NewEdge(tenantID, workflowID, sourceStepID, targetStepID uuid.UUID, condition string) *Edge {
 	var cond *string
 	if condition != "" {
 		cond = &condition
 	}
 	return &Edge{
 		ID:           uuid.New(),
+		TenantID:     tenantID,
 		WorkflowID:   workflowID,
 		SourceStepID: sourceStepID,
 		TargetStepID: targetStepID,
@@ -37,13 +39,14 @@ func NewEdge(workflowID, sourceStepID, targetStepID uuid.UUID, condition string)
 }
 
 // NewEdgeWithPort creates a new edge with specific source and target ports
-func NewEdgeWithPort(workflowID, sourceStepID, targetStepID uuid.UUID, sourcePort, targetPort, condition string) *Edge {
+func NewEdgeWithPort(tenantID, workflowID, sourceStepID, targetStepID uuid.UUID, sourcePort, targetPort, condition string) *Edge {
 	var cond *string
 	if condition != "" {
 		cond = &condition
 	}
 	return &Edge{
 		ID:           uuid.New(),
+		TenantID:     tenantID,
 		WorkflowID:   workflowID,
 		SourceStepID: sourceStepID,
 		TargetStepID: targetStepID,

--- a/backend/internal/domain/edge_test.go
+++ b/backend/internal/domain/edge_test.go
@@ -8,13 +8,15 @@ import (
 )
 
 func TestNewEdge(t *testing.T) {
+	tenantID := uuid.New()
 	workflowID := uuid.New()
 	sourceID := uuid.New()
 	targetID := uuid.New()
 
-	edge := NewEdge(workflowID, sourceID, targetID, "condition == true")
+	edge := NewEdge(tenantID, workflowID, sourceID, targetID, "condition == true")
 
 	assert.NotEqual(t, uuid.Nil, edge.ID)
+	assert.Equal(t, tenantID, edge.TenantID)
 	assert.Equal(t, workflowID, edge.WorkflowID)
 	assert.Equal(t, sourceID, edge.SourceStepID)
 	assert.Equal(t, targetID, edge.TargetStepID)
@@ -24,13 +26,15 @@ func TestNewEdge(t *testing.T) {
 }
 
 func TestNewEdge_WithoutCondition(t *testing.T) {
+	tenantID := uuid.New()
 	workflowID := uuid.New()
 	sourceID := uuid.New()
 	targetID := uuid.New()
 
-	edge := NewEdge(workflowID, sourceID, targetID, "")
+	edge := NewEdge(tenantID, workflowID, sourceID, targetID, "")
 
 	assert.NotEqual(t, uuid.Nil, edge.ID)
+	assert.Equal(t, tenantID, edge.TenantID)
 	assert.Equal(t, workflowID, edge.WorkflowID)
 	assert.Equal(t, sourceID, edge.SourceStepID)
 	assert.Equal(t, targetID, edge.TargetStepID)

--- a/backend/internal/domain/step.go
+++ b/backend/internal/domain/step.go
@@ -70,6 +70,7 @@ func (t StepType) IsValid() bool {
 // Step represents a node in the DAG
 type Step struct {
 	ID           uuid.UUID       `json:"id"`
+	TenantID     uuid.UUID       `json:"tenant_id"`
 	WorkflowID   uuid.UUID       `json:"workflow_id"`
 	Name         string          `json:"name"`
 	Type         StepType        `json:"type"`
@@ -96,10 +97,11 @@ func (s *Step) GetCredentialBindings() (map[string]uuid.UUID, error) {
 }
 
 // NewStep creates a new step
-func NewStep(workflowID uuid.UUID, name string, stepType StepType, config json.RawMessage) *Step {
+func NewStep(tenantID, workflowID uuid.UUID, name string, stepType StepType, config json.RawMessage) *Step {
 	now := time.Now().UTC()
 	return &Step{
 		ID:                 uuid.New(),
+		TenantID:           tenantID,
 		WorkflowID:         workflowID,
 		Name:               name,
 		Type:               stepType,

--- a/backend/internal/domain/step_run.go
+++ b/backend/internal/domain/step_run.go
@@ -21,6 +21,7 @@ const (
 // StepRun represents a single step execution within a run
 type StepRun struct {
 	ID          uuid.UUID       `json:"id"`
+	TenantID    uuid.UUID       `json:"tenant_id"`
 	RunID       uuid.UUID       `json:"run_id"`
 	StepID      uuid.UUID       `json:"step_id"`
 	StepName    string          `json:"step_name"`
@@ -36,9 +37,10 @@ type StepRun struct {
 }
 
 // NewStepRun creates a new step run
-func NewStepRun(runID, stepID uuid.UUID, stepName string) *StepRun {
+func NewStepRun(tenantID, runID, stepID uuid.UUID, stepName string) *StepRun {
 	return &StepRun{
 		ID:        uuid.New(),
+		TenantID:  tenantID,
 		RunID:     runID,
 		StepID:    stepID,
 		StepName:  stepName,
@@ -49,9 +51,10 @@ func NewStepRun(runID, stepID uuid.UUID, stepName string) *StepRun {
 }
 
 // NewStepRunWithAttempt creates a new step run with a specific attempt number (for re-execution)
-func NewStepRunWithAttempt(runID, stepID uuid.UUID, stepName string, attempt int) *StepRun {
+func NewStepRunWithAttempt(tenantID, runID, stepID uuid.UUID, stepName string, attempt int) *StepRun {
 	return &StepRun{
 		ID:        uuid.New(),
+		TenantID:  tenantID,
 		RunID:     runID,
 		StepID:    stepID,
 		StepName:  stepName,

--- a/backend/internal/domain/step_test.go
+++ b/backend/internal/domain/step_test.go
@@ -55,12 +55,14 @@ func TestValidStepTypes(t *testing.T) {
 }
 
 func TestNewStep(t *testing.T) {
+	tenantID := uuid.New()
 	workflowID := uuid.New()
 	config := json.RawMessage(`{"adapter_id": "mock", "settings": {"timeout": 30}}`)
 
-	step := NewStep(workflowID, "Test Step", StepTypeTool, config)
+	step := NewStep(tenantID, workflowID, "Test Step", StepTypeTool, config)
 
 	assert.NotEqual(t, uuid.Nil, step.ID)
+	assert.Equal(t, tenantID, step.TenantID)
 	assert.Equal(t, workflowID, step.WorkflowID)
 	assert.Equal(t, "Test Step", step.Name)
 	assert.Equal(t, StepTypeTool, step.Type)

--- a/backend/internal/engine/executor.go
+++ b/backend/internal/engine/executor.go
@@ -144,7 +144,7 @@ func (e *Executor) ExecuteSingleStep(ctx context.Context, execCtx *ExecutionCont
 	)
 
 	// Create step run
-	stepRun := domain.NewStepRun(execCtx.Run.ID, targetStep.ID, targetStep.Name)
+	stepRun := domain.NewStepRun(execCtx.Run.TenantID, execCtx.Run.ID, targetStep.ID, targetStep.Name)
 
 	execCtx.mu.Lock()
 	execCtx.StepRuns[targetStep.ID] = stepRun
@@ -508,7 +508,7 @@ func (e *Executor) executeNode(ctx context.Context, execCtx *ExecutionContext, g
 	)
 
 	// Create step run
-	stepRun := domain.NewStepRun(execCtx.Run.ID, step.ID, step.Name)
+	stepRun := domain.NewStepRun(execCtx.Run.TenantID, execCtx.Run.ID, step.ID, step.Name)
 
 	execCtx.mu.Lock()
 	execCtx.StepRuns[step.ID] = stepRun

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -30,19 +30,20 @@ type WorkflowFilter struct {
 // StepRepository defines the interface for step persistence
 type StepRepository interface {
 	Create(ctx context.Context, step *domain.Step) error
-	GetByID(ctx context.Context, workflowID, id uuid.UUID) (*domain.Step, error)
-	ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*domain.Step, error)
+	GetByID(ctx context.Context, tenantID, workflowID, id uuid.UUID) (*domain.Step, error)
+	ListByWorkflow(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Step, error)
+	ListByBlockGroup(ctx context.Context, tenantID, blockGroupID uuid.UUID) ([]*domain.Step, error)
 	Update(ctx context.Context, step *domain.Step) error
-	Delete(ctx context.Context, workflowID, id uuid.UUID) error
+	Delete(ctx context.Context, tenantID, workflowID, id uuid.UUID) error
 }
 
 // EdgeRepository defines the interface for edge persistence
 type EdgeRepository interface {
 	Create(ctx context.Context, edge *domain.Edge) error
-	GetByID(ctx context.Context, workflowID, id uuid.UUID) (*domain.Edge, error)
-	ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*domain.Edge, error)
-	Delete(ctx context.Context, workflowID, id uuid.UUID) error
-	Exists(ctx context.Context, workflowID, sourceID, targetID uuid.UUID) (bool, error)
+	GetByID(ctx context.Context, tenantID, workflowID, id uuid.UUID) (*domain.Edge, error)
+	ListByWorkflow(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Edge, error)
+	Delete(ctx context.Context, tenantID, workflowID, id uuid.UUID) error
+	Exists(ctx context.Context, tenantID, workflowID, sourceID, targetID uuid.UUID) (bool, error)
 }
 
 // RunRepository defines the interface for run persistence
@@ -65,20 +66,20 @@ type RunFilter struct {
 // StepRunRepository defines the interface for step run persistence
 type StepRunRepository interface {
 	Create(ctx context.Context, stepRun *domain.StepRun) error
-	GetByID(ctx context.Context, runID, id uuid.UUID) (*domain.StepRun, error)
-	ListByRun(ctx context.Context, runID uuid.UUID) ([]*domain.StepRun, error)
+	GetByID(ctx context.Context, tenantID, runID, id uuid.UUID) (*domain.StepRun, error)
+	ListByRun(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.StepRun, error)
 	Update(ctx context.Context, stepRun *domain.StepRun) error
 
 	// GetMaxAttempt returns the highest attempt number for a step in a run
-	GetMaxAttempt(ctx context.Context, runID, stepID uuid.UUID) (int, error)
+	GetMaxAttempt(ctx context.Context, tenantID, runID, stepID uuid.UUID) (int, error)
 	// GetMaxAttemptForRun returns the highest attempt number across all steps in a run
-	GetMaxAttemptForRun(ctx context.Context, runID uuid.UUID) (int, error)
+	GetMaxAttemptForRun(ctx context.Context, tenantID, runID uuid.UUID) (int, error)
 	// GetLatestByStep returns the most recent StepRun for a step in a run
-	GetLatestByStep(ctx context.Context, runID, stepID uuid.UUID) (*domain.StepRun, error)
+	GetLatestByStep(ctx context.Context, tenantID, runID, stepID uuid.UUID) (*domain.StepRun, error)
 	// ListCompletedByRun returns the latest completed StepRun for each step in a run
-	ListCompletedByRun(ctx context.Context, runID uuid.UUID) ([]*domain.StepRun, error)
+	ListCompletedByRun(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.StepRun, error)
 	// ListByStep returns all StepRuns for a specific step in a run (for history)
-	ListByStep(ctx context.Context, runID, stepID uuid.UUID) ([]*domain.StepRun, error)
+	ListByStep(ctx context.Context, tenantID, runID, stepID uuid.UUID) ([]*domain.StepRun, error)
 }
 
 // WorkflowVersionRepository defines the interface for workflow version persistence
@@ -189,18 +190,18 @@ type BlockVersionRepository interface {
 // BlockGroupRepository defines the interface for block group persistence
 type BlockGroupRepository interface {
 	Create(ctx context.Context, group *domain.BlockGroup) error
-	GetByID(ctx context.Context, id uuid.UUID) (*domain.BlockGroup, error)
-	ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*domain.BlockGroup, error)
-	ListByParent(ctx context.Context, parentID uuid.UUID) ([]*domain.BlockGroup, error)
+	GetByID(ctx context.Context, tenantID, id uuid.UUID) (*domain.BlockGroup, error)
+	ListByWorkflow(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.BlockGroup, error)
+	ListByParent(ctx context.Context, tenantID, parentID uuid.UUID) ([]*domain.BlockGroup, error)
 	Update(ctx context.Context, group *domain.BlockGroup) error
-	Delete(ctx context.Context, id uuid.UUID) error
+	Delete(ctx context.Context, tenantID, id uuid.UUID) error
 }
 
 // BlockGroupRunRepository defines the interface for block group run persistence
 type BlockGroupRunRepository interface {
 	Create(ctx context.Context, run *domain.BlockGroupRun) error
-	GetByID(ctx context.Context, id uuid.UUID) (*domain.BlockGroupRun, error)
-	ListByRun(ctx context.Context, runID uuid.UUID) ([]*domain.BlockGroupRun, error)
+	GetByID(ctx context.Context, tenantID, id uuid.UUID) (*domain.BlockGroupRun, error)
+	ListByRun(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.BlockGroupRun, error)
 	Update(ctx context.Context, run *domain.BlockGroupRun) error
 }
 

--- a/backend/internal/usecase/block_group.go
+++ b/backend/internal/usecase/block_group.go
@@ -64,7 +64,7 @@ func (u *BlockGroupUsecase) Create(ctx context.Context, input CreateBlockGroupIn
 
 	// Verify parent group if specified
 	if input.ParentGroupID != nil {
-		parent, err := u.blockGroupRepo.GetByID(ctx, *input.ParentGroupID)
+		parent, err := u.blockGroupRepo.GetByID(ctx, input.TenantID, *input.ParentGroupID)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (u *BlockGroupUsecase) Create(ctx context.Context, input CreateBlockGroupIn
 		}
 	}
 
-	group := domain.NewBlockGroup(input.WorkflowID, input.Name, input.Type)
+	group := domain.NewBlockGroup(input.TenantID, input.WorkflowID, input.Name, input.Type)
 	if input.Config != nil {
 		group.Config = input.Config
 	}
@@ -100,7 +100,7 @@ func (u *BlockGroupUsecase) GetByID(ctx context.Context, tenantID, workflowID, g
 		return nil, err
 	}
 
-	group, err := u.blockGroupRepo.GetByID(ctx, groupID)
+	group, err := u.blockGroupRepo.GetByID(ctx, tenantID, groupID)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (u *BlockGroupUsecase) List(ctx context.Context, tenantID, workflowID uuid.
 	if _, err := u.workflowRepo.GetByID(ctx, tenantID, workflowID); err != nil {
 		return nil, err
 	}
-	return u.blockGroupRepo.ListByWorkflow(ctx, workflowID)
+	return u.blockGroupRepo.ListByWorkflow(ctx, tenantID, workflowID)
 }
 
 // UpdateBlockGroupInput represents input for updating a block group
@@ -147,7 +147,7 @@ func (u *BlockGroupUsecase) Update(ctx context.Context, input UpdateBlockGroupIn
 		return nil, domain.ErrWorkflowNotEditable
 	}
 
-	group, err := u.blockGroupRepo.GetByID(ctx, input.GroupID)
+	group, err := u.blockGroupRepo.GetByID(ctx, input.TenantID, input.GroupID)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (u *BlockGroupUsecase) Delete(ctx context.Context, tenantID, workflowID, gr
 		return domain.ErrWorkflowNotEditable
 	}
 
-	group, err := u.blockGroupRepo.GetByID(ctx, groupID)
+	group, err := u.blockGroupRepo.GetByID(ctx, tenantID, groupID)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (u *BlockGroupUsecase) Delete(ctx context.Context, tenantID, workflowID, gr
 		return domain.ErrBlockGroupNotFound
 	}
 
-	return u.blockGroupRepo.Delete(ctx, groupID)
+	return u.blockGroupRepo.Delete(ctx, tenantID, groupID)
 }
 
 // AddStepToGroupInput represents input for adding a step to a block group
@@ -235,7 +235,7 @@ func (u *BlockGroupUsecase) AddStepToGroup(ctx context.Context, input AddStepToG
 	}
 
 	// Verify group exists
-	group, err := u.blockGroupRepo.GetByID(ctx, input.GroupID)
+	group, err := u.blockGroupRepo.GetByID(ctx, input.TenantID, input.GroupID)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (u *BlockGroupUsecase) AddStepToGroup(ctx context.Context, input AddStepToG
 	}
 
 	// Get step
-	step, err := u.stepRepo.GetByID(ctx, input.WorkflowID, input.StepID)
+	step, err := u.stepRepo.GetByID(ctx, input.TenantID, input.WorkflowID, input.StepID)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (u *BlockGroupUsecase) RemoveStepFromGroup(ctx context.Context, tenantID, w
 	}
 
 	// Get step
-	step, err := u.stepRepo.GetByID(ctx, workflowID, stepID)
+	step, err := u.stepRepo.GetByID(ctx, tenantID, workflowID, stepID)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (u *BlockGroupUsecase) GetStepsByGroup(ctx context.Context, tenantID, workf
 	}
 
 	// Verify group exists
-	group, err := u.blockGroupRepo.GetByID(ctx, groupID)
+	group, err := u.blockGroupRepo.GetByID(ctx, tenantID, groupID)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (u *BlockGroupUsecase) GetStepsByGroup(ctx context.Context, tenantID, workf
 	}
 
 	// Get steps in group
-	steps, err := u.stepRepo.ListByWorkflow(ctx, workflowID)
+	steps, err := u.stepRepo.ListByWorkflow(ctx, tenantID, workflowID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/edge.go
+++ b/backend/internal/usecase/edge.go
@@ -56,15 +56,15 @@ func (u *EdgeUsecase) Create(ctx context.Context, input CreateEdgeInput) (*domai
 	}
 
 	// Verify both steps exist
-	if _, err := u.stepRepo.GetByID(ctx, input.WorkflowID, input.SourceStepID); err != nil {
+	if _, err := u.stepRepo.GetByID(ctx, input.TenantID, input.WorkflowID, input.SourceStepID); err != nil {
 		return nil, err
 	}
-	if _, err := u.stepRepo.GetByID(ctx, input.WorkflowID, input.TargetStepID); err != nil {
+	if _, err := u.stepRepo.GetByID(ctx, input.TenantID, input.WorkflowID, input.TargetStepID); err != nil {
 		return nil, err
 	}
 
 	// Check for duplicate
-	exists, err := u.edgeRepo.Exists(ctx, input.WorkflowID, input.SourceStepID, input.TargetStepID)
+	exists, err := u.edgeRepo.Exists(ctx, input.TenantID, input.WorkflowID, input.SourceStepID, input.TargetStepID)
 	if err != nil {
 		return nil, err
 	}
@@ -73,16 +73,16 @@ func (u *EdgeUsecase) Create(ctx context.Context, input CreateEdgeInput) (*domai
 	}
 
 	// Check if adding this edge would create a cycle
-	edges, err := u.edgeRepo.ListByWorkflow(ctx, input.WorkflowID)
+	edges, err := u.edgeRepo.ListByWorkflow(ctx, input.TenantID, input.WorkflowID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Temporarily add the new edge and check for cycle
-	newEdge := domain.NewEdgeWithPort(input.WorkflowID, input.SourceStepID, input.TargetStepID, input.SourcePort, input.TargetPort, input.Condition)
+	newEdge := domain.NewEdgeWithPort(input.TenantID, input.WorkflowID, input.SourceStepID, input.TargetStepID, input.SourcePort, input.TargetPort, input.Condition)
 	allEdges := append(edges, newEdge)
 
-	steps, err := u.stepRepo.ListByWorkflow(ctx, input.WorkflowID)
+	steps, err := u.stepRepo.ListByWorkflow(ctx, input.TenantID, input.WorkflowID)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (u *EdgeUsecase) List(ctx context.Context, tenantID, workflowID uuid.UUID) 
 	if _, err := u.workflowRepo.GetByID(ctx, tenantID, workflowID); err != nil {
 		return nil, err
 	}
-	return u.edgeRepo.ListByWorkflow(ctx, workflowID)
+	return u.edgeRepo.ListByWorkflow(ctx, tenantID, workflowID)
 }
 
 // Delete deletes an edge
@@ -157,5 +157,5 @@ func (u *EdgeUsecase) Delete(ctx context.Context, tenantID, workflowID, edgeID u
 		return domain.ErrWorkflowNotEditable
 	}
 
-	return u.edgeRepo.Delete(ctx, workflowID, edgeID)
+	return u.edgeRepo.Delete(ctx, tenantID, workflowID, edgeID)
 }

--- a/backend/internal/usecase/run_test.go
+++ b/backend/internal/usecase/run_test.go
@@ -101,80 +101,87 @@ func (m *mockVersionRepo) ListByWorkflow(ctx context.Context, workflowID uuid.UU
 }
 
 type mockStepRepo struct {
-	listByWorkflowFn func(ctx context.Context, workflowID uuid.UUID) ([]*domain.Step, error)
+	listByWorkflowFn func(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Step, error)
 }
 
-func (m *mockStepRepo) Create(ctx context.Context, step *domain.Step) error       { return nil }
-func (m *mockStepRepo) GetByID(ctx context.Context, workflowID, id uuid.UUID) (*domain.Step, error) {
+func (m *mockStepRepo) Create(ctx context.Context, step *domain.Step) error { return nil }
+func (m *mockStepRepo) GetByID(ctx context.Context, tenantID, workflowID, id uuid.UUID) (*domain.Step, error) {
 	return nil, nil
 }
-func (m *mockStepRepo) ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*domain.Step, error) {
+func (m *mockStepRepo) ListByWorkflow(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Step, error) {
 	if m.listByWorkflowFn != nil {
-		return m.listByWorkflowFn(ctx, workflowID)
+		return m.listByWorkflowFn(ctx, tenantID, workflowID)
 	}
 	return nil, nil
 }
-func (m *mockStepRepo) Update(ctx context.Context, step *domain.Step) error              { return nil }
-func (m *mockStepRepo) Delete(ctx context.Context, workflowID, id uuid.UUID) error       { return nil }
+func (m *mockStepRepo) ListByBlockGroup(ctx context.Context, tenantID, blockGroupID uuid.UUID) ([]*domain.Step, error) {
+	return nil, nil
+}
+func (m *mockStepRepo) Update(ctx context.Context, step *domain.Step) error { return nil }
+func (m *mockStepRepo) Delete(ctx context.Context, tenantID, workflowID, id uuid.UUID) error {
+	return nil
+}
 
 type mockEdgeRepo struct {
-	listByWorkflowFn func(ctx context.Context, workflowID uuid.UUID) ([]*domain.Edge, error)
+	listByWorkflowFn func(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Edge, error)
 }
 
-func (m *mockEdgeRepo) Create(ctx context.Context, edge *domain.Edge) error        { return nil }
-func (m *mockEdgeRepo) GetByID(ctx context.Context, workflowID, id uuid.UUID) (*domain.Edge, error) {
+func (m *mockEdgeRepo) Create(ctx context.Context, edge *domain.Edge) error { return nil }
+func (m *mockEdgeRepo) GetByID(ctx context.Context, tenantID, workflowID, id uuid.UUID) (*domain.Edge, error) {
 	return nil, nil
 }
-func (m *mockEdgeRepo) ListByWorkflow(ctx context.Context, workflowID uuid.UUID) ([]*domain.Edge, error) {
+func (m *mockEdgeRepo) ListByWorkflow(ctx context.Context, tenantID, workflowID uuid.UUID) ([]*domain.Edge, error) {
 	if m.listByWorkflowFn != nil {
-		return m.listByWorkflowFn(ctx, workflowID)
+		return m.listByWorkflowFn(ctx, tenantID, workflowID)
 	}
 	return nil, nil
 }
-func (m *mockEdgeRepo) Delete(ctx context.Context, workflowID, id uuid.UUID) error                 { return nil }
-func (m *mockEdgeRepo) Exists(ctx context.Context, workflowID, sourceID, targetID uuid.UUID) (bool, error) {
+func (m *mockEdgeRepo) Delete(ctx context.Context, tenantID, workflowID, id uuid.UUID) error {
+	return nil
+}
+func (m *mockEdgeRepo) Exists(ctx context.Context, tenantID, workflowID, sourceID, targetID uuid.UUID) (bool, error) {
 	return false, nil
 }
 
 type mockStepRunRepo struct {
-	getLatestByStepFn     func(ctx context.Context, runID, stepID uuid.UUID) (*domain.StepRun, error)
-	getMaxAttemptForRunFn func(ctx context.Context, runID uuid.UUID) (int, error)
-	listCompletedByRunFn  func(ctx context.Context, runID uuid.UUID) ([]*domain.StepRun, error)
-	listByStepFn          func(ctx context.Context, runID, stepID uuid.UUID) ([]*domain.StepRun, error)
+	getLatestByStepFn     func(ctx context.Context, tenantID, runID, stepID uuid.UUID) (*domain.StepRun, error)
+	getMaxAttemptForRunFn func(ctx context.Context, tenantID, runID uuid.UUID) (int, error)
+	listCompletedByRunFn  func(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.StepRun, error)
+	listByStepFn          func(ctx context.Context, tenantID, runID, stepID uuid.UUID) ([]*domain.StepRun, error)
 }
 
 func (m *mockStepRunRepo) Create(ctx context.Context, stepRun *domain.StepRun) error { return nil }
-func (m *mockStepRunRepo) GetByID(ctx context.Context, runID, id uuid.UUID) (*domain.StepRun, error) {
+func (m *mockStepRunRepo) GetByID(ctx context.Context, tenantID, runID, id uuid.UUID) (*domain.StepRun, error) {
 	return nil, nil
 }
-func (m *mockStepRunRepo) ListByRun(ctx context.Context, runID uuid.UUID) ([]*domain.StepRun, error) {
+func (m *mockStepRunRepo) ListByRun(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.StepRun, error) {
 	return nil, nil
 }
 func (m *mockStepRunRepo) Update(ctx context.Context, stepRun *domain.StepRun) error { return nil }
-func (m *mockStepRunRepo) GetMaxAttempt(ctx context.Context, runID, stepID uuid.UUID) (int, error) {
+func (m *mockStepRunRepo) GetMaxAttempt(ctx context.Context, tenantID, runID, stepID uuid.UUID) (int, error) {
 	return 0, nil
 }
-func (m *mockStepRunRepo) GetMaxAttemptForRun(ctx context.Context, runID uuid.UUID) (int, error) {
+func (m *mockStepRunRepo) GetMaxAttemptForRun(ctx context.Context, tenantID, runID uuid.UUID) (int, error) {
 	if m.getMaxAttemptForRunFn != nil {
-		return m.getMaxAttemptForRunFn(ctx, runID)
+		return m.getMaxAttemptForRunFn(ctx, tenantID, runID)
 	}
 	return 0, nil
 }
-func (m *mockStepRunRepo) GetLatestByStep(ctx context.Context, runID, stepID uuid.UUID) (*domain.StepRun, error) {
+func (m *mockStepRunRepo) GetLatestByStep(ctx context.Context, tenantID, runID, stepID uuid.UUID) (*domain.StepRun, error) {
 	if m.getLatestByStepFn != nil {
-		return m.getLatestByStepFn(ctx, runID, stepID)
+		return m.getLatestByStepFn(ctx, tenantID, runID, stepID)
 	}
 	return nil, nil
 }
-func (m *mockStepRunRepo) ListCompletedByRun(ctx context.Context, runID uuid.UUID) ([]*domain.StepRun, error) {
+func (m *mockStepRunRepo) ListCompletedByRun(ctx context.Context, tenantID, runID uuid.UUID) ([]*domain.StepRun, error) {
 	if m.listCompletedByRunFn != nil {
-		return m.listCompletedByRunFn(ctx, runID)
+		return m.listCompletedByRunFn(ctx, tenantID, runID)
 	}
 	return nil, nil
 }
-func (m *mockStepRunRepo) ListByStep(ctx context.Context, runID, stepID uuid.UUID) ([]*domain.StepRun, error) {
+func (m *mockStepRunRepo) ListByStep(ctx context.Context, tenantID, runID, stepID uuid.UUID) ([]*domain.StepRun, error) {
 	if m.listByStepFn != nil {
-		return m.listByStepFn(ctx, runID, stepID)
+		return m.listByStepFn(ctx, tenantID, runID, stepID)
 	}
 	return nil, nil
 }
@@ -419,7 +426,7 @@ func TestRunUsecase_GetStepHistory(t *testing.T) {
 	}
 
 	stepRunRepo := &mockStepRunRepo{
-		listByStepFn: func(ctx context.Context, rid, sid uuid.UUID) ([]*domain.StepRun, error) {
+		listByStepFn: func(ctx context.Context, tid, rid, sid uuid.UUID) ([]*domain.StepRun, error) {
 			if rid == runID && sid == stepID {
 				return stepRuns, nil
 			}
@@ -549,13 +556,13 @@ func TestRunUsecase_GetWithDetailsAndDefinition_FallbackToWorkflow(t *testing.T)
 	}
 
 	stepRepo := &mockStepRepo{
-		listByWorkflowFn: func(ctx context.Context, wid uuid.UUID) ([]*domain.Step, error) {
+		listByWorkflowFn: func(ctx context.Context, tid, wid uuid.UUID) ([]*domain.Step, error) {
 			return steps, nil
 		},
 	}
 
 	edgeRepo := &mockEdgeRepo{
-		listByWorkflowFn: func(ctx context.Context, wid uuid.UUID) ([]*domain.Edge, error) {
+		listByWorkflowFn: func(ctx context.Context, tid, wid uuid.UUID) ([]*domain.Edge, error) {
 			return []*domain.Edge{}, nil
 		},
 	}

--- a/backend/internal/usecase/step.go
+++ b/backend/internal/usecase/step.go
@@ -71,7 +71,7 @@ func (u *StepUsecase) Create(ctx context.Context, input CreateStepInput) (*domai
 		}
 	}
 
-	step := domain.NewStep(input.WorkflowID, input.Name, input.Type, input.Config)
+	step := domain.NewStep(input.TenantID, input.WorkflowID, input.Name, input.Type, input.Config)
 	if blockDef != nil {
 		step.BlockDefinitionID = &blockDef.ID
 	}
@@ -90,7 +90,7 @@ func (u *StepUsecase) GetByID(ctx context.Context, tenantID, workflowID, stepID 
 	if _, err := u.workflowRepo.GetByID(ctx, tenantID, workflowID); err != nil {
 		return nil, err
 	}
-	return u.stepRepo.GetByID(ctx, workflowID, stepID)
+	return u.stepRepo.GetByID(ctx, tenantID, workflowID, stepID)
 }
 
 // List lists steps for a workflow
@@ -99,7 +99,7 @@ func (u *StepUsecase) List(ctx context.Context, tenantID, workflowID uuid.UUID) 
 	if _, err := u.workflowRepo.GetByID(ctx, tenantID, workflowID); err != nil {
 		return nil, err
 	}
-	return u.stepRepo.ListByWorkflow(ctx, workflowID)
+	return u.stepRepo.ListByWorkflow(ctx, tenantID, workflowID)
 }
 
 // UpdateStepInput represents input for updating a step
@@ -125,7 +125,7 @@ func (u *StepUsecase) Update(ctx context.Context, input UpdateStepInput) (*domai
 		return nil, domain.ErrWorkflowNotEditable
 	}
 
-	step, err := u.stepRepo.GetByID(ctx, input.WorkflowID, input.StepID)
+	step, err := u.stepRepo.GetByID(ctx, input.TenantID, input.WorkflowID, input.StepID)
 	if err != nil {
 		return nil, err
 	}
@@ -164,5 +164,5 @@ func (u *StepUsecase) Delete(ctx context.Context, tenantID, workflowID, stepID u
 		return domain.ErrWorkflowNotEditable
 	}
 
-	return u.stepRepo.Delete(ctx, workflowID, stepID)
+	return u.stepRepo.Delete(ctx, tenantID, workflowID, stepID)
 }

--- a/backend/schema/schema.sql
+++ b/backend/schema/schema.sql
@@ -148,6 +148,7 @@ COMMENT ON COLUMN public.block_definitions.version IS 'Version number, increment
 
 CREATE TABLE public.block_group_runs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
+    tenant_id uuid NOT NULL,
     run_id uuid NOT NULL,
     block_group_id uuid NOT NULL,
     status character varying(50) DEFAULT 'pending'::character varying,
@@ -168,6 +169,7 @@ CREATE TABLE public.block_group_runs (
 
 CREATE TABLE public.block_groups (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
+    tenant_id uuid NOT NULL,
     workflow_id uuid NOT NULL,
     name character varying(255) NOT NULL,
     type character varying(50) NOT NULL,
@@ -340,6 +342,7 @@ COMMENT ON COLUMN public.credentials.metadata IS 'Non-sensitive metadata (e.g., 
 
 CREATE TABLE public.edges (
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    tenant_id uuid NOT NULL,
     workflow_id uuid NOT NULL,
     source_step_id uuid NOT NULL,
     target_step_id uuid NOT NULL,
@@ -459,6 +462,7 @@ CREATE TABLE public.secrets (
 
 CREATE TABLE public.step_runs (
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    tenant_id uuid NOT NULL,
     run_id uuid NOT NULL,
     step_id uuid NOT NULL,
     step_name character varying(255) NOT NULL,
@@ -480,6 +484,7 @@ CREATE TABLE public.step_runs (
 
 CREATE TABLE public.steps (
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    tenant_id uuid NOT NULL,
     workflow_id uuid NOT NULL,
     name character varying(255) NOT NULL,
     type character varying(50) NOT NULL,
@@ -1212,6 +1217,20 @@ CREATE INDEX idx_block_groups_workflow ON public.block_groups USING btree (workf
 
 
 --
+-- Name: idx_block_groups_tenant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_block_groups_tenant ON public.block_groups USING btree (tenant_id);
+
+
+--
+-- Name: idx_block_group_runs_tenant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_block_group_runs_tenant ON public.block_group_runs USING btree (tenant_id);
+
+
+--
 -- Name: idx_block_versions_block_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1289,6 +1308,13 @@ CREATE INDEX idx_credentials_type ON public.credentials USING btree (credential_
 
 
 --
+-- Name: idx_edges_tenant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_edges_tenant ON public.edges USING btree (tenant_id);
+
+
+--
 -- Name: idx_edges_source_port; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1352,10 +1378,24 @@ CREATE INDEX idx_step_runs_run ON public.step_runs USING btree (run_id);
 
 
 --
+-- Name: idx_step_runs_tenant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_step_runs_tenant ON public.step_runs USING btree (tenant_id);
+
+
+--
 -- Name: idx_steps_block_group; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_steps_block_group ON public.steps USING btree (block_group_id);
+
+
+--
+-- Name: idx_steps_tenant; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_steps_tenant ON public.steps USING btree (tenant_id);
 
 
 --
@@ -1602,6 +1642,14 @@ ALTER TABLE ONLY public.block_group_runs
 
 
 --
+-- Name: block_group_runs block_group_runs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.block_group_runs
+    ADD CONSTRAINT block_group_runs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
+
+
+--
 -- Name: block_groups block_groups_parent_group_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1615,6 +1663,14 @@ ALTER TABLE ONLY public.block_groups
 
 ALTER TABLE ONLY public.block_groups
     ADD CONSTRAINT block_groups_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES public.workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: block_groups block_groups_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.block_groups
+    ADD CONSTRAINT block_groups_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
@@ -1671,6 +1727,14 @@ ALTER TABLE ONLY public.edges
 
 ALTER TABLE ONLY public.edges
     ADD CONSTRAINT edges_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES public.workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: edges edges_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edges
+    ADD CONSTRAINT edges_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --
@@ -1762,6 +1826,14 @@ ALTER TABLE ONLY public.step_runs
 
 
 --
+-- Name: step_runs step_runs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.step_runs
+    ADD CONSTRAINT step_runs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
+
+
+--
 -- Name: steps steps_block_definition_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1783,6 +1855,14 @@ ALTER TABLE ONLY public.steps
 
 ALTER TABLE ONLY public.steps
     ADD CONSTRAINT steps_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES public.workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: steps steps_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.steps
+    ADD CONSTRAINT steps_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id);
 
 
 --


### PR DESCRIPTION
## Summary

- Defense in Depthの一環として、steps/edges/block_groups/step_runs/block_group_runsテーブルにtenant_idカラムを追加
- 全リポジトリクエリをtenant_idでフィルタリングするように更新
- ドメイン型、ユースケース、エンジン、workerの呼び出し元を修正

## Changes

### Database Schema
- `steps`: tenant_id カラム + FK + インデックス追加
- `edges`: tenant_id カラム + FK + インデックス追加
- `block_groups`: tenant_id カラム + FK + インデックス追加
- `step_runs`: tenant_id カラム + FK + インデックス追加
- `block_group_runs`: tenant_id カラム + FK + インデックス追加

### Domain
- `Step`, `Edge`, `BlockGroup`, `StepRun`, `BlockGroupRun`構造体にTenantIDフィールド追加
- コンストラクタ関数（NewStep, NewEdge, NewBlockGroup, NewStepRun等）にtenantIDパラメータ追加

### Repository
- 全CRUD操作にtenant_idフィルタを追加
- インターフェース定義を更新

### Usecase/Worker/Engine
- リポジトリ呼び出し元を全て修正
- tenantIDを適切に伝播

## Test plan

- [x] `go build ./...` が成功
- [x] `go test ./internal/... ./pkg/...` が全て成功
- [ ] CIが成功

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)