### PR TITLE
refactor: useSchedules/useAuditLogs/useWebhooksをuseApi()を使用するようにリファクタリング

### DIFF
--- a/frontend/composables/useSchedules.ts
+++ b/frontend/composables/useSchedules.ts
@@ -1,34 +1,11 @@
 import type { Schedule, CreateScheduleRequest, UpdateScheduleRequest, ApiResponse, PaginatedResponse } from '~/types/api'
 
 export function useSchedules() {
-  const config = useRuntimeConfig()
-  const baseUrl = config.public.apiBase || 'http://localhost:8080'
+  const api = useApi()
 
   const schedules = ref<Schedule[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
-
-  const getHeaders = () => {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    }
-
-    // Add tenant ID header for development (client-side only)
-    if (import.meta.client) {
-      const tenantId = localStorage.getItem('tenant_id') || '00000000-0000-0000-0000-000000000001'
-      headers['X-Tenant-ID'] = tenantId
-
-      // Add auth token if available
-      const token = localStorage.getItem('auth_token')
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
-    } else {
-      headers['X-Tenant-ID'] = '00000000-0000-0000-0000-000000000001'
-    }
-
-    return headers
-  }
 
   const list = async (workflowId?: string): Promise<Schedule[]> => {
     loading.value = true
@@ -39,15 +16,9 @@ export function useSchedules() {
         params.append('workflow_id', workflowId)
       }
       const queryString = params.toString()
-      const url = `${baseUrl}/schedules${queryString ? `?${queryString}` : ''}`
+      const endpoint = `/schedules${queryString ? `?${queryString}` : ''}`
 
-      const response = await fetch(url, {
-        headers: getHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to fetch schedules: ${response.statusText}`)
-      }
-      const result: PaginatedResponse<Schedule> = await response.json()
+      const result = await api.get<PaginatedResponse<Schedule>>(endpoint)
       schedules.value = result.data || []
       return result.data || []
     } catch (e) {
@@ -62,13 +33,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules/${id}`, {
-        headers: getHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to fetch schedule: ${response.statusText}`)
-      }
-      const result: ApiResponse<Schedule> = await response.json()
+      const result = await api.get<ApiResponse<Schedule>>(`/schedules/${id}`)
       return result.data
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Unknown error'
@@ -82,15 +47,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules`, {
-        method: 'POST',
-        headers: getHeaders(),
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to create schedule: ${response.statusText}`)
-      }
-      const result: ApiResponse<Schedule> = await response.json()
+      const result = await api.post<ApiResponse<Schedule>>('/schedules', data)
       schedules.value.push(result.data)
       return result.data
     } catch (e) {
@@ -105,15 +62,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules/${id}`, {
-        method: 'PUT',
-        headers: getHeaders(),
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to update schedule: ${response.statusText}`)
-      }
-      const result: ApiResponse<Schedule> = await response.json()
+      const result = await api.put<ApiResponse<Schedule>>(`/schedules/${id}`, data)
       const index = schedules.value.findIndex(s => s.id === id)
       if (index !== -1) {
         schedules.value[index] = result.data
@@ -131,13 +80,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules/${id}`, {
-        method: 'DELETE',
-        headers: getHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to delete schedule: ${response.statusText}`)
-      }
+      await api.delete(`/schedules/${id}`)
       schedules.value = schedules.value.filter(s => s.id !== id)
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Unknown error'
@@ -151,14 +94,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules/${id}/pause`, {
-        method: 'POST',
-        headers: getHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to pause schedule: ${response.statusText}`)
-      }
-      const result: ApiResponse<Schedule> = await response.json()
+      const result = await api.post<ApiResponse<Schedule>>(`/schedules/${id}/pause`)
       const index = schedules.value.findIndex(s => s.id === id)
       if (index !== -1) {
         schedules.value[index] = result.data
@@ -176,14 +112,7 @@ export function useSchedules() {
     loading.value = true
     error.value = null
     try {
-      const response = await fetch(`${baseUrl}/schedules/${id}/resume`, {
-        method: 'POST',
-        headers: getHeaders(),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to resume schedule: ${response.statusText}`)
-      }
-      const result: ApiResponse<Schedule> = await response.json()
+      const result = await api.post<ApiResponse<Schedule>>(`/schedules/${id}/resume`)
       const index = schedules.value.findIndex(s => s.id === id)
       if (index !== -1) {
         schedules.value[index] = result.data


### PR DESCRIPTION
## Summary
- `useSchedules.ts`、`useAuditLogs.ts`、`useWebhooks.ts`を`useApi()`を使用するパターンに統一
- 直接`fetch()`を使用していた実装から`useApi()`を使用する実装に変更
- `getHeaders()`関数とbaseUrl変数を削除し、コードの重複を解消

## 変更内容

| ファイル | 変更点 |
|---------|--------|
| useSchedules.ts | `getHeaders()`と`baseUrl`変数を削除、`api.get/post/put/delete`を使用 |
| useAuditLogs.ts | `getHeaders()`と`baseUrl`変数を削除、`api.get`を使用 |
| useWebhooks.ts | `getHeaders()`を削除、`api.get/post/put/delete`を使用（`baseUrl`は`getWebhookUrl()`で必要なため維持） |

## メリット
- 認証ロジックが`useApi.ts`に一元化され、変更時の修正箇所が1箇所に
- コードの重複を削除（約180行削減）
- 他のcomposablesとの一貫性を確保

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run test:run` パス（167 tests passed）

Closes #50, Closes #51, Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)