### PR TITLE
refactor: copilot.goのjson.Marshalにエラーハンドリングを追加

### DIFF
--- a/backend/internal/usecase/copilot.go
+++ b/backend/internal/usecase/copilot.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -524,7 +525,11 @@ func buildExplainPrompt(workflow *domain.Workflow, stepID *uuid.UUID) string {
 
 	sb.WriteString("## Steps\n")
 	for _, step := range workflow.Steps {
-		configJSON, _ := json.Marshal(step.Config)
+		configJSON, err := json.Marshal(step.Config)
+		if err != nil {
+			slog.Warn("failed to marshal step config", "step_id", step.ID, "error", err)
+			configJSON = []byte("{}")
+		}
 		sb.WriteString(fmt.Sprintf("- %s (%s): %s\n", step.Name, step.Type, string(configJSON)))
 	}
 
@@ -549,7 +554,11 @@ func buildOptimizePrompt(workflow *domain.Workflow) string {
 	sb.WriteString(fmt.Sprintf("Steps: %d\n\n", len(workflow.Steps)))
 
 	for _, step := range workflow.Steps {
-		configJSON, _ := json.Marshal(step.Config)
+		configJSON, err := json.Marshal(step.Config)
+		if err != nil {
+			slog.Warn("failed to marshal step config", "step_id", step.ID, "error", err)
+			configJSON = []byte("{}")
+		}
 		sb.WriteString(fmt.Sprintf("- %s (%s): %s\n", step.Name, step.Type, string(configJSON)))
 	}
 


### PR DESCRIPTION
## Summary
- `buildExplainPrompt`と`buildOptimizePrompt`関数でjson.Marshalのエラーを適切にハンドリング
- エラー発生時はログ出力して空のJSON (`{}`) にフォールバック
- AGENTS.mdの「Explicit error handling (no `_` ignore)」ルールに準拠

Closes #46

## Test plan
- [x] `go build ./...` が成功すること
- [x] `go test ./...` が成功すること（E2EはDB接続不要なため対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)