### PR TITLE
refactor: ratelimit.goのjson.Encodeにエラーハンドリングを追加

### DIFF
--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -162,7 +163,7 @@ func writeRateLimitError(w http.ResponseWriter, result *RateLimitResult, scope R
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Retry-After", strconv.FormatInt(int64(time.Until(result.ResetAt).Seconds()), 10))
 	w.WriteHeader(http.StatusTooManyRequests)
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"error": map[string]interface{}{
 			"code":       "RATE_LIMIT_EXCEEDED",
 			"message":    fmt.Sprintf("Rate limit exceeded for %s scope", scope),
@@ -170,7 +171,9 @@ func writeRateLimitError(w http.ResponseWriter, result *RateLimitResult, scope R
 			"limit":      result.Limit,
 			"scope":      scope,
 		},
-	})
+	}); err != nil {
+		slog.Error("failed to encode rate limit error response", "error", err, "scope", scope)
+	}
 }
 
 // TenantRateLimitMiddleware creates a middleware that rate limits by tenant


### PR DESCRIPTION
## Summary
- `writeRateLimitError`関数で`json.NewEncoder().Encode()`のエラーを適切にハンドリング
- エラー発生時は`slog.Error`でログ出力
- レートリミットはセキュリティ機能のため、エラーログは重要

Closes #44

## Test plan
- [x] `go build ./...` が成功すること
- [x] `go test ./internal/middleware/...` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)