### PR TITLE
refactor: sandbox.goのHTTPClient.Requestでbytes.NewReaderを使用

### DIFF
--- a/backend/internal/block/sandbox/sandbox.go
+++ b/backend/internal/block/sandbox/sandbox.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -558,7 +559,7 @@ func (c *HTTPClient) Request(method, url string, body interface{}, options map[s
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		bodyReader = strings.NewReader(string(bodyJSON))
+		bodyReader = bytes.NewReader(bodyJSON)
 	}
 
 	req, err := http.NewRequest(method, url, bodyReader)


### PR DESCRIPTION
## Summary
- `strings.NewReader(string(bodyJSON))` を `bytes.NewReader(bodyJSON)` に変更
- 不要な `[]byte` → `string` 変換によるメモリ割り当てを削減

## Changes
- `bytes` パッケージをimportに追加
- HTTPClient.Request内の bodyReader 生成で bytes.NewReader を使用

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/block/sandbox/...` 全テストパス

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)