### PR TITLE
docs: APIドキュメントにスキーマ検証エラーの記載を追加

### DIFF
--- a/backend/internal/handler/response.go
+++ b/backend/internal/handler/response.go
@@ -75,6 +75,15 @@ func Error(w http.ResponseWriter, status int, code, message string, details inte
 
 // HandleError converts domain errors to HTTP responses
 func HandleError(w http.ResponseWriter, err error) {
+	// Check for input schema validation errors first
+	var inputValidationErrs *domain.InputValidationErrors
+	if errors.As(err, &inputValidationErrs) {
+		Error(w, http.StatusBadRequest, "SCHEMA_VALIDATION_ERROR", "Input validation failed", map[string]interface{}{
+			"errors": inputValidationErrs.Errors,
+		})
+		return
+	}
+
 	var validationErr domain.ValidationError
 	if errors.As(err, &validationErr) {
 		Error(w, http.StatusBadRequest, "VALIDATION_ERROR", validationErr.Message, map[string]string{

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,9 +40,39 @@ REST API endpoints, request/response schemas, and authentication.
 | `FORBIDDEN` | 403 | Insufficient permissions |
 | `NOT_FOUND` | 404 | Resource not found |
 | `VALIDATION_ERROR` | 400 | Invalid request body |
+| `SCHEMA_VALIDATION_ERROR` | 400 | Input does not match workflow's input_schema |
 | `CONFLICT` | 409 | Resource conflict |
 | `INTERNAL_ERROR` | 500 | Server error |
 | `RATE_LIMIT_EXCEEDED` | 429 | Rate limit exceeded |
+
+### Schema Validation Error Response
+
+When the input data does not match the workflow's `input_schema` (defined in the Start step), the API returns a detailed validation error:
+
+```json
+{
+  "error": {
+    "code": "SCHEMA_VALIDATION_ERROR",
+    "message": "Input validation failed",
+    "details": {
+      "errors": [
+        {
+          "field": "email",
+          "message": "email is required"
+        },
+        {
+          "field": "age",
+          "message": "age must be of type integer"
+        }
+      ]
+    }
+  }
+}
+```
+
+This error is returned by:
+- `POST /workflows/{workflow_id}/runs` - when run input doesn't match workflow's input_schema
+- `POST /webhooks/{webhook_id}` - when webhook payload (after input_mapping) doesn't match workflow's input_schema
 
 ---
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -492,6 +492,8 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/Run'
+        '400':
+          $ref: '#/components/responses/SchemaValidationError'
 
   /runs/{runId}:
     parameters:
@@ -725,6 +727,8 @@ paths:
                     format: uuid
                   status:
                     type: string
+        '400':
+          $ref: '#/components/responses/SchemaValidationError'
 
   /adapters:
     get:
@@ -2082,3 +2086,33 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    SchemaValidationError:
+      description: input_schemaに対する入力データ検証エラー
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: SCHEMA_VALIDATION_ERROR
+                  message:
+                    type: string
+                    example: Input validation failed
+                  details:
+                    type: object
+                    properties:
+                      errors:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            field:
+                              type: string
+                              example: email
+                            message:
+                              type: string
+                              example: email is required


### PR DESCRIPTION
## Summary

- HandleErrorにInputValidationErrorsのハンドリングを追加
- SCHEMA_VALIDATION_ERRORエラーコードを新設
- API.mdにスキーマ検証エラーのレスポンス形式を追記
- openapi.yamlにSchemaValidationErrorレスポンスを追加
- POST /workflows/{id}/runs と POST /webhooks/{id} に400レスポンスを追加

## Test plan

- [x] go test ./... でバックエンドテストがすべて成功
- [x] TestHandleError_InputValidationErrors が成功

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)